### PR TITLE
remove mcp_approval_request and mcp_approval_response from event

### DIFF
--- a/specification/ai/data-plane/VoiceLive/events.tsp
+++ b/specification/ai/data-plane/VoiceLive/events.tsp
@@ -86,12 +86,6 @@ union ServerEventType {
   response_mcp_call_arguments_done: "response.mcp_call_arguments.done",
 
   @added(Versions.v2026_01_01_preview)
-  mcp_approval_request: "mcp_approval_request",
-
-  @added(Versions.v2026_01_01_preview)
-  mcp_approval_response: "mcp_approval_response",
-
-  @added(Versions.v2026_01_01_preview)
   response_mcp_call_in_progress: "response.mcp_call.in_progress",
 
   @added(Versions.v2026_01_01_preview)

--- a/specification/ai/data-plane/VoiceLive/preview/2026-01-01-preview/GeneratedSystemEvents.json
+++ b/specification/ai/data-plane/VoiceLive/preview/2026-01-01-preview/GeneratedSystemEvents.json
@@ -5054,8 +5054,6 @@
         "mcp_list_tools.failed",
         "response.mcp_call_arguments.delta",
         "response.mcp_call_arguments.done",
-        "mcp_approval_request",
-        "mcp_approval_response",
         "response.mcp_call.in_progress",
         "response.mcp_call.completed",
         "response.mcp_call.failed",
@@ -5232,14 +5230,6 @@
           {
             "name": "response_mcp_call_arguments_done",
             "value": "response.mcp_call_arguments.done"
-          },
-          {
-            "name": "mcp_approval_request",
-            "value": "mcp_approval_request"
-          },
-          {
-            "name": "mcp_approval_response",
-            "value": "mcp_approval_response"
           },
           {
             "name": "response_mcp_call_in_progress",


### PR DESCRIPTION
They are one of items in conversation.item.create or conversation.item.created

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
