### PR TITLE
Fix RequestAudioContentPart constructor visibility for C#

### DIFF
--- a/specification/ai/data-plane/VoiceLive/client.tsp
+++ b/specification/ai/data-plane/VoiceLive/client.tsp
@@ -111,6 +111,7 @@ using Azure.ClientGenerator.Core;
 
 @@access(VoiceLive.ServerEvent, Access.public, "csharp");
 @@access(VoiceLive.ServerEventSessionCreated, Access.public, "csharp");
+@@access(VoiceLive.RequestAudioContentPart, Access.public, "csharp");
 @@access(VoiceLive.ClientEvent, Access.internal, "csharp");
 @@access(VoiceLive.ClientEventConversationItemCreate,
   Access.internal,


### PR DESCRIPTION
Fix RequestAudioContentPart constructor visibility for C#
Internal -> Public